### PR TITLE
Dockerfile 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# base image
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 as base
+WORKDIR /app
+EXPOSE 80
+
+# build image
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as build
+WORKDIR /SlackCoffee
+COPY . .
+RUN dotnet publish -c Release -o /app
+
+FROM base as final
+WORKDIR /app
+COPY --from=build /app .
+RUN ls -al
+ENTRYPOINT ["./SlackCoffee", "--urls=http://0.0.0.0:80"]


### PR DESCRIPTION
ASP .NET Core 3.1 이미지로 빌드하는 Dockerfile을 추가합니다.

ENTRYPOINT 에서 `--urls` 인자를 이용하여 웹서버에서 외부 80 포트를 열어서 사용하도록 합니다.